### PR TITLE
estep calibration: fixing sign error and extension length

### DIFF
--- a/data/www/index.html
+++ b/data/www/index.html
@@ -184,7 +184,7 @@
           <label for="rightMotorTool" class="form-label">Right Motor</label>
           <input type="range" class="form-range mb-5 text-center" min="-1" max="1" id="rightMotorTool" value="0">
           <button class="w-100 btn btn-lg btn-primary mb-5" id="parkServoTool">Park Servo</button>
-          <button class="w-100 btn btn-lg btn-primary mb-5" id="estepsTool">Extend 100mm (E-steps calibration)</button>
+          <button class="w-100 btn btn-lg btn-primary mb-5" id="estepsTool">Extend 1000mm (E-steps calibration)</button>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -264,13 +264,13 @@ Movement::Point Movement::getCoordinates() {
     return Movement::Point(X, Y);
 }
 
-void Movement::extend100mm() {
-    auto steps = int((100 / circumference) * stepsPerRotation);
-    
+void Movement::extend1000mm() {
+    const int steps = int((1000 / circumference) * stepsPerRotation);
+
     leftMotor->move(steps);
     leftMotor->setSpeed(moveSpeedSteps);
 
-    rightMotor->move(-steps);
+    rightMotor->move(steps);
     rightMotor->setSpeed(moveSpeedSteps);
 
     moving = true;

--- a/src/movement.h
+++ b/src/movement.h
@@ -12,8 +12,8 @@ const auto diameter = 12.65;
 const auto circumference = diameter * PI;
 const auto bottomDistance = 67.4;
 const auto midPulleyToWall = 41;
-const auto safeYFraction = 0.2;
-const auto safeXFraction = 0.2;
+const auto safeYFraction = 0.2;     // Top Margin: Image top to topDistance line.
+const auto safeXFraction = 0.2;     // Left and right margin: from draw area boundaries to line from each pin straight down.
 
 const auto LEFT_STEP_PIN = 13;
 const auto LEFT_DIR_PIN = 12;
@@ -93,7 +93,10 @@ void rightStepper(int dir);
 int extendToHome();
 void runSteppers();
 float beginLinearTravel(double x, double y, int speed);
-void extend100mm();
+
+// Used for calibration of the esteps.
+void extend1000mm(); 
+
 Point getHomeCoordinates();
 void disableMotors();
 };

--- a/src/phases/settopdistancephase.cpp
+++ b/src/phases/settopdistancephase.cpp
@@ -23,8 +23,8 @@ void SetTopDistancePhase::setServo(AsyncWebServerRequest *request) {
 }
 
 void SetTopDistancePhase::estepsCalibration(AsyncWebServerRequest* request) {
-    Serial.println("Extending 100mm");
-    movement->extend100mm();
+    Serial.println("Extending 1000mm");
+    movement->extend1000mm();
     request->send(200, "text/plain", "OK");
 }
 


### PR DESCRIPTION
This PR addresses two things for the estep calibration:

1) The sign of the movement of the right motor is flipped, so the motor does extend the belt rather than retracting. (This was a bug.)

2) The extension length is changed from 100mm to 1000mm. This was done to improve the accuracy of the calibration procedure, as it avoids rounding errors of the step count accumulating with each button press.
In my case it brought the calibration error over 2500mm down from 14mm to 0mm!
(I did also adjust the pulley diameter from 12.65mm to 12.69mm in my build. This is not included in the PR as it might depend on the hardware acquired.)

The code has been tested on the bot and works fine. One caveat though: The button text did not change - I assume this is cached somewhere and needs to be refreshed @nikivanov ?!