### PR TITLE
Belt calibration fix

### DIFF
--- a/data/www/index.html
+++ b/data/www/index.html
@@ -184,7 +184,7 @@
           <label for="rightMotorTool" class="form-label">Right Motor</label>
           <input type="range" class="form-range mb-5 text-center" min="-1" max="1" id="rightMotorTool" value="0">
           <button class="w-100 btn btn-lg btn-primary mb-5" id="parkServoTool">Park Servo</button>
-          <button class="w-100 btn btn-lg btn-primary mb-5" id="estepsTool">Extend 100mm (E-steps calibration)</button>
+          <button class="w-100 btn btn-lg btn-primary mb-5" id="estepsTool">Extend 1000mm (E-steps calibration)</button>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -264,13 +264,13 @@ Movement::Point Movement::getCoordinates() {
     return Movement::Point(X, Y);
 }
 
-void Movement::extend100mm() {
-    auto steps = int((100 / circumference) * stepsPerRotation);
-    
+void Movement::extend1000mm() {
+    const int steps = int((1000 / circumference) * stepsPerRotation);
+
     leftMotor->move(steps);
     leftMotor->setSpeed(moveSpeedSteps);
 
-    rightMotor->move(-steps);
+    rightMotor->move(steps);
     rightMotor->setSpeed(moveSpeedSteps);
 
     moving = true;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -102,7 +102,7 @@ Movement::Point Movement::getHomeCoordinates() {
         return Point(0, 0);
     }
 
-    return Point(width / 2, HOME_Y_OFFSE_MM);
+    return Point(width / 2, HOME_Y_OFFSET_MM);
 }
 
 int Movement::extendToHome()

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -102,7 +102,7 @@ Movement::Point Movement::getHomeCoordinates() {
         return Point(0, 0);
     }
 
-    return Point(width / 2, HOME_Y_OFFSET);
+    return Point(width / 2, HOME_Y_OFFSE_MM);
 }
 
 int Movement::extendToHome()

--- a/src/movement.h
+++ b/src/movement.h
@@ -1,103 +1,109 @@
 #ifndef Movement_h
 #define Movement_h
+
+#include "AccelStepper.h"
 #include "Arduino.h" 
 #include "display.h"
-#include "AccelStepper.h"
-const auto printSpeedSteps = 500;
-const auto moveSpeedSteps = 1500;
-const long INFINITE_STEPS = 999999999;
-const auto acceleration = 999999999; //essentially infinite, causing instant stop / start
-const int stepsPerRotation = 200 * 8; // 1/8 microstepping
-const auto diameter = 12.65;
-const auto circumference = diameter * PI;
-const auto bottomDistance = 67.4;
-const auto midPulleyToWall = 41;
-const auto safeYFraction = 0.2;     // Top Margin: Image top to topDistance line.
-const auto safeXFraction = 0.2;     // Left and right margin: from draw area boundaries to line from each pin straight down.
 
-const auto LEFT_STEP_PIN = 13;
-const auto LEFT_DIR_PIN = 12;
-const auto LEFT_ENABLE_PIN = 14;
+// Motor driver parameters.
+constexpr int printSpeedSteps = 500;
+constexpr int  moveSpeedSteps = 1500;
+constexpr long INFINITE_STEPS = 999999999;
+constexpr long acceleration = 999999999;    // Essentially infinite, causing instant stop / start.
+constexpr int stepsPerRotation = 200 * 8;   // 1/8 microstepping
 
-const auto RIGHT_STEP_PIN = 27;
-const auto RIGHT_DIR_PIN = 26;
-const auto RIGHT_ENABLE_PIN = 25;
-
-
-
-const auto homedStepOffsetMM = 17;
+// Geometry parameters:
+// Effective diameter of the pulley+belts. Use EStep calibration to refine this value.
+constexpr double diameter = 12.69;
+const double circumference = diameter * PI;
+constexpr double bottomDistance = 67.4;
+constexpr double midPulleyToWall = 41.0;    // (Height) distance from mid of pulley to wall [mm].
+constexpr float homedStepOffsetMM = 40.0;   // Length of fully retracted belt hitting stop screw.
+                                            // Measured from outer edge of screw to the point
+                                            // of tangency between belt and pulley. [mm]
 const int homedStepsOffset = int((homedStepOffsetMM / circumference) * stepsPerRotation);
+const int HOME_Y_OFFSET_MM = 350;   // Y coordinate of mural home position in image coordinate system [mm].
 
 
+// Margins used for transformations of the coordinate systems:
+constexpr double safeYFraction = 0.2;       // Top margin: Image top to topDistance line.
+constexpr double safeXFraction = 0.2;       // Left and right margin: From draw area boundaries to line from each pin straight down.
+
+// ESP setup:
+constexpr int LEFT_STEP_PIN = 13;
+constexpr int LEFT_DIR_PIN = 12;
+constexpr int LEFT_ENABLE_PIN = 14;
+
+constexpr int RIGHT_STEP_PIN = 27;
+constexpr int RIGHT_DIR_PIN = 26;
+constexpr int RIGHT_ENABLE_PIN = 25;
 
 class Movement{
 private:
-int topDistance;
-double minSafeY;
-double minSafeXOffset;
-double width;
-volatile bool moving;
-bool homed;
-double X = -1;
-double Y = -1;
-bool startedHoming;
-AccelStepper *leftMotor;
-AccelStepper *rightMotor;
-Display *display;
-void setOrigin();
+    int topDistance;            // Distance between pins (d_pins) [mm].
+    double minSafeY;
+    double minSafeXOffset;
+    double width;               // width of the drawing area [mm]
+    volatile bool moving;
+    bool homed;
+    double X = -1;              // Location of Pen in x [mm].
+    double Y = -1;              // Location of Pen in y [mm].
+    bool startedHoming;
+    AccelStepper *leftMotor;
+    AccelStepper *rightMotor;
+    Display *display;
+    void setOrigin();
 
+    struct Lengths {
+        int left;
+        int right;
+        Lengths(int left, int right) {
+            this->left = left;
+            this->right = right;
+        }
+        Lengths() {
 
+        }
+    };
 
-struct Lengths {
-    int left;
-    int right;
-    Lengths(int left, int right) {
-        this->left = left;
-        this->right = right;
-    }
-    Lengths() {
+    Lengths getBeltLengths(double x, double y);
 
-    }
-};
-
-Lengths getBeltLengths(double x, double y);
 public:
-Movement(Display *display);
-struct Point {
-    double x;
-    double y;
-    Point(double x, double y) {
-        this->x = x;
-        this->y = y;
+    Movement(Display *display);
+    struct Point {
+        double x;
+        double y;
+        Point(double x, double y) {
+            this->x = x;
+            this->y = y;
+        }
+        Point() {
+
+        }
+    };
+
+    static double distanceBetweenPoints(Point point1, Point point2) {
+        return sqrt(pow(point2.x - point1.x, 2) + pow(point2.y - point1.y, 2));
     }
-    Point() {
-        
-    }
+
+    bool isMoving();
+    bool hasStartedHoming();
+    double getWidth();
+    Point getCoordinates();
+    void setTopDistance(int distance);
+    void resumeTopDistance(int distance);
+    int getTopDistance();
+    void leftStepper(int dir);
+    void rightStepper(int dir);
+    int extendToHome();
+    void runSteppers();
+    float beginLinearTravel(double x, double y, int speed);
+
+    // Used for calibration of the esteps.
+    void extend100mm();
+
+    Point getHomeCoordinates();
+    void disableMotors();
 };
 
-const int HOME_Y_OFFSET = 350;
-
-static double distanceBetweenPoints(Point point1, Point point2) {
-    return sqrt(pow(point2.x - point1.x, 2) + pow(point2.y - point1.y, 2));
-}
-
-bool isMoving();
-bool hasStartedHoming();
-double getWidth();
-Point getCoordinates();
-void setTopDistance(int distance);
-void resumeTopDistance(int distance);
-int getTopDistance();
-void leftStepper(int dir);
-void rightStepper(int dir);
-int extendToHome();
-void runSteppers();
-float beginLinearTravel(double x, double y, int speed);
-
-// Used for calibration of the esteps.
-void extend1000mm(); 
-
-Point getHomeCoordinates();
-void disableMotors();
-};
 #endif

--- a/src/movement.h
+++ b/src/movement.h
@@ -12,8 +12,8 @@ const auto diameter = 12.65;
 const auto circumference = diameter * PI;
 const auto bottomDistance = 67.4;
 const auto midPulleyToWall = 41;
-const auto safeYFraction = 0.2;
-const auto safeXFraction = 0.2;
+const auto safeYFraction = 0.2;     // Top Margin: Image top to topDistance line.
+const auto safeXFraction = 0.2;     // Left and right margin: from draw area boundaries to line from each pin straight down.
 
 const auto LEFT_STEP_PIN = 13;
 const auto LEFT_DIR_PIN = 12;
@@ -93,7 +93,10 @@ void rightStepper(int dir);
 int extendToHome();
 void runSteppers();
 float beginLinearTravel(double x, double y, int speed);
-void extend100mm();
+
+// Used for calibration of the esteps.
+void extend1000mm(); 
+
 Point getHomeCoordinates();
 void disableMotors();
 };

--- a/src/movement.h
+++ b/src/movement.h
@@ -100,7 +100,7 @@ public:
     float beginLinearTravel(double x, double y, int speed);
 
     // Used for calibration of the esteps.
-    void extend100mm();
+    void extend1000mm();
 
     Point getHomeCoordinates();
     void disableMotors();

--- a/src/phases/settopdistancephase.cpp
+++ b/src/phases/settopdistancephase.cpp
@@ -23,8 +23,8 @@ void SetTopDistancePhase::setServo(AsyncWebServerRequest *request) {
 }
 
 void SetTopDistancePhase::estepsCalibration(AsyncWebServerRequest* request) {
-    Serial.println("Extending 100mm");
-    movement->extend100mm();
+    Serial.println("Extending 1000mm");
+    movement->extend1000mm();
     request->send(200, "text/plain", "OK");
 }
 


### PR DESCRIPTION
This PR depends on [PR#41](https://github.com/nikivanov/mural/pull/41) - please merge it first (and resync)!



This PR addresses the geometric distortion by fixing an error with the calibration offset of the belts. The only functional change is:

`homedStepOffsetMM = 40.0;` instead of `homedStepOffsetMM = 17.0;`. 

I assume this bug occurred because the "belt only" distance was measured before (i.e. belt loop edge to pulley). However, we should measure screw to pulley (with the screw representing the pin.

All other changes are for improving code readability only: Using explicit types instead of auto reduces the risk of unintended type casting.

## Results
Using a anchor distance of 1.3m I'm drawing a straight line on the wall and compare it with a true straight line (ground truth  "GT"). You can see the setup and results here.

![PXL_20250523_112535510](https://github.com/user-attachments/assets/d6d3b090-486d-4f85-b7d6-4534f638fa31)
The lower line is the stock firmware with a curvature error of 14.0mm in the center of the line.
The top line (with a shifted GT line in red) shows the result of this PR. See line "fixed belt offset error". The remaining error is ~3.5mm, so about 4x better than before.

Here's a closeup:
![PXL_20250523_112548825](https://github.com/user-attachments/assets/f477a024-56ac-4e46-bfbb-5c6e1b67182f)

(Please ignore the other lines - these are other experiments/fixes I'm currently working on.)

